### PR TITLE
Creating www is not optional at the moment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo raspi-config
 * update apt-get
 sudo apt-get update
 
-* make a directory for your web apps (optional, but suggested)
+* make a directory for your web apps
 mkdir www
 cd www
 


### PR DESCRIPTION
Get this error when running the configure script

```
./configure.sh: 25: cd: can't cd to /root/www/subnodes/
```

Should also update the script to allow for any directory. Might try that if I get some time.
