### PR TITLE
fix empty network config after uninstall

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -52,7 +52,7 @@ case $yn in
 		# restore the previous interfaces file
 		echo -en "Restoring previous network interfaces configuration file... 			"
 		rm /etc/network/interfaces
-		mv /etc/network/interfaces.bak /etc/network/interfaces
+		mv /etc/network/interfaces.orig.bak /etc/network/interfaces
 		echo -en "[OK]\n"
 
 		# Remove startup scripts and delete


### PR DESCRIPTION
network interfaces config file was not restored properly after uninstall
In the `install.sh` the config file was backed up with `.orig.bak` extension, not `.bak`