### PR TITLE
Support all home dir usernames

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -149,7 +149,7 @@ echo ""
 # install chat room
 echo "Installing chat room..."
 # go back to our subnodes directory
-cd /home/pi/subnodes/
+cd "$(dirname $(readlink -f $0))"
 
 # download subnodes app dependencies
 npm install

--- a/scripts/subnodes_ap.sh
+++ b/scripts/subnodes_ap.sh
@@ -16,7 +16,7 @@
 
 NAME=subnodes_ap
 DESC="Brings up wireless access point for connecting to web server running on the device."
-DAEMON_PATH="/home/pi/subnodes"
+DAEMON_PATH="$(dirname "$(pwd)")"
 DAEMONOPTS="sudo NODE_ENV=production PORT=80 nodemon subnode.js"
 PIDFILE=/var/run/$NAME.pid
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -73,8 +73,8 @@ case $yn in
 		rm /etc/subnodes.config
 
 		echo "Deleting subnodes folder"
-		cd /home/pi/
-		rm -rf /home/pi/subnodes
+		cd "$(dirname "$(pwd)")"
+		rm -rf subnodes
 		echo -en "[OK]\n"
 		read -p "Do you wish to reboot now? [N] " yn
 		case $yn in


### PR DESCRIPTION
This update adds support for all home-directory usernames.

-----

## Issue
Missing directory errors

## Cause
Default packages point to ```/home/pi/...```

If username is other than ```pi```;  
```install.sh```, ```uninstall.sh```, & ```/scripts/subnodes_ap.sh``` will throw missing directory errors.

## Expected result
Install, run, and be uninstalled with no directory errors.

## Reproduction  
Have username other than ```pi```  

```cd subnodes```
```sudo bash install.sh``` || ```sudo ./install.sh```

## Suggested Fix

replace:  
```cd /home/pi/subnodes/```  

with:  
```cd "$(dirname $(readlink -f $0))"```

[**/subnodes/install.sh#L152**](https://github.com/chootka/subnodes/blob/132c8b1a3ea37106befd6e513f4c59a4f9fbec1e/install.sh#L152)

#

replace:  
- ```cd /home/pi/```  
```rm -rf /home/pi/subnodes```  

with:  
- ```cd "$(dirname "$(pwd)")"```
```rm -rf subnodes```  

[**/subnodes/uninstall.sh#L76**](https://github.com/chootka/subnodes/blob/132c8b1a3ea37106befd6e513f4c59a4f9fbec1e/uninstall.sh#L76)  
 [**/subnodes/uninstall.sh#L77**](https://github.com/chootka/subnodes/blob/132c8b1a3ea37106befd6e513f4c59a4f9fbec1e/uninstall.sh#L77)

#

replace:  
```DAEMON_PATH="/home/pi/subnodes"```  

with:  
```DAEMON_PATH="$(dirname "$(pwd)")"```  

[**/subnodes/scripts/subnodes_ap.sh#L19**](https://github.com/chootka/subnodes/blob/132c8b1a3ea37106befd6e513f4c59a4f9fbec1e/scripts/subnodes_ap.sh#L19)

#

## Results after Suggested Fix
No missing directory errors.
subnodes installs as expected.  

-----